### PR TITLE
fix console links

### DIFF
--- a/walkthroughs/3-low-code-api-development/walkthrough.adoc
+++ b/walkthroughs/3-low-code-api-development/walkthrough.adoc
@@ -3,7 +3,7 @@
 
 // URLs
 :fuse-documentation-url: https://access.redhat.com/documentation/en-us/red_hat_fuse/{fuse-version}/
-:openshift-console-url: {openshift-host}/console
+:openshift-console-url: {openshift-host}/dashboards
 :route: https://wt3-{user-username}-3scale.{openshift-app-host}
 
 //attributes

--- a/walkthroughs/4-protecting-apis/walkthrough.adoc
+++ b/walkthroughs/4-protecting-apis/walkthrough.adoc
@@ -3,7 +3,7 @@
 :3scale-version: 2.7
 
 // URLs
-:openshift-console-url: {openshift-host}/console
+:openshift-console-url: {openshift-host}/dashboards
 :route: https://wt4-{user-username}-3scale.{openshift-app-host}
 
 //attributes

--- a/walkthroughs/5-adding-data-sync-graphql/walkthrough.adoc
+++ b/walkthroughs/5-adding-data-sync-graphql/walkthrough.adoc
@@ -2,7 +2,7 @@
 :rhmi-version: 1
 
 // URLs
-:openshift-console-url: {openshift-host}/console
+:openshift-console-url: {openshift-host}/dashboards
 :sso-realm-url: {user-sso-url}/auth/admin/solution-patterns/console/index.html
 :data-sync-documentation-url: https://access.redhat.com/documentation/en-us/red_hat_managed_integration/{rhmi-version}/html-single/developing_a_data_sync_app/index
 


### PR DESCRIPTION
On OS4 the console has the `/dashboards` endpoint