### PR TITLE
Fix wt2 os4

### DIFF
--- a/walkthroughs/1-connecting-apps-asynchronous-messaging/walkthrough.adoc
+++ b/walkthroughs/1-connecting-apps-asynchronous-messaging/walkthrough.adoc
@@ -38,14 +38,14 @@ image::images/arch.png[integration, role="integr8ly-img-responsive"]
 * link:https://blog.openshift.com/[OpenShift Blog, window="_blank"]
 ****
 
-[type=walkthroughResource,serviceName=fuse]
+[type=walkthroughResource,serviceName=fuse-managed]
 .Red Hat Fuse Online
 ****
 * link:{fuse-url}[Console, window="_blank", id="resources-fuse-url"]
 * link:{fuse-documentation-url}[Fuse Documentation, window="_blank"]
 ****
 
-[type=walkthroughResource,serviceName=amq-online-standard]
+[type=walkthroughResource,serviceName=amqonline]
 .Red Hat AMQ
 ****
 * link:{enmasse-url}[Console, window="_blank", , id="resources-enmasse-url"]

--- a/walkthroughs/2-protecting-apps-sso/walkthrough.adoc
+++ b/walkthroughs/2-protecting-apps-sso/walkthrough.adoc
@@ -48,7 +48,7 @@ image::images/arch.png[integration, role="integr8ly-img-responsive"]
 * link:https://blog.openshift.com/[OpenShift Blog, window="_blank"]
 ****
 
-[type=walkthroughResource,serviceName=sso,subs=attributes+]
+[type=walkthroughResource,serviceName=user-rhsso,subs=attributes+]
 .Customer Application SSO
 ****
 * link:{sso-realm-url}[Console, window="_blank"]

--- a/walkthroughs/2-protecting-apps-sso/walkthrough.adoc
+++ b/walkthroughs/2-protecting-apps-sso/walkthrough.adoc
@@ -77,8 +77,8 @@ Red Hat manages this instance, however there are some additional users with admi
 Follow these steps to create a client.
 
 . Go to the link:{sso-realm-url}[Master, window="_blank"] realm, which is running on your {customer-sso-name} service.
-.. If prompted, login with your credentials. You will see the *Master* realm if the login is successful.
-.. Hover the *Master* realm dropdown and click on *Add Realm*.
+.. If prompted, log in with your username and password. You will see the *Master* realm if the login is successful.
+.. Hover the realms dropdown in the top left and click on *Add Realm*.
 .. Enter *realm-{user-username}* as the name and click *Create*. You will be redirected to your new realm.
 . Select *Clients* from the vertical navigation menu on the left side of the screen.
 . Click the *Create* button on the top right of the Clients screen.
@@ -109,7 +109,7 @@ To secure your application with single sign-on and allow additional users to log
 Follow these steps to create a new user and set that user's password.
 
 . Go to the link:{sso-user-realm-url}[{realm-name}, window="_blank"] realm, which is running on your {customer-sso-name} service.
-.. If prompted, login with your credentials.
+.. If prompted, log in with your username and password.
 . You will see the *{realm-name}* realm if the login is successful.
 . Select *Users* from the vertical navigation menu on the left side of the screen.
 . Click the *Add user* button on the top right of the Users screen.
@@ -159,7 +159,7 @@ demonstrate how to include a configuration and enable the adapter.
 
 
 . Go to link:{sso-user-realm-url}[SSO Realm, window="_blank"].
-. Login with your credentials if prompted.
+. If prompted, log in with your username and password.
 . Select *Clients* from the side menu.
 . Click the `{client-name}` client that was created earlier.
 . Choose the *Installation* tab.

--- a/walkthroughs/2-protecting-apps-sso/walkthrough.adoc
+++ b/walkthroughs/2-protecting-apps-sso/walkthrough.adoc
@@ -4,7 +4,7 @@
 // URLs
 :openshift-console-url: {openshift-host}/dashboards
 :sso-adapter-docs-url: https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/{sso-version}/html/securing_applications_and_services_guide/index
-:sso-realm-url: {user-sso-url}/auth/admin/solution-patterns/console/index.html
+:sso-realm-url: {user-sso-url}
 
 //attributes
 :title: 2 - Protecting applications using single sign-on

--- a/walkthroughs/2-protecting-apps-sso/walkthrough.adoc
+++ b/walkthroughs/2-protecting-apps-sso/walkthrough.adoc
@@ -158,8 +158,8 @@ The *{create-messages-app}* is run from a Node.js server, so the Node.js
 demonstrate how to include a configuration and enable the adapter.
 
 
-. Go to link:{sso-realm-url}[SSO Realm, window="_blank"].
-. Enter the username `{shared-realm-username}` and password `{realm-password}` if prompted.
+. Go to link:{sso-user-realm-url}[SSO Realm, window="_blank"].
+. Login with your credentials if prompted.
 . Select *Clients* from the side menu.
 . Click the `{client-name}` client that was created earlier.
 . Choose the *Installation* tab.

--- a/walkthroughs/2-protecting-apps-sso/walkthrough.adoc
+++ b/walkthroughs/2-protecting-apps-sso/walkthrough.adoc
@@ -169,13 +169,18 @@ demonstrate how to include a configuration and enable the adapter.
 === Creating a SSO Config Map Entry
 
 . Login to the link:{openshift-console-url}[OpenShift Console, window="_blank"].
-. Select the project that contains *integration-solution-1-integrate-event-and-api-driven-apps* in the name.
-. Select *Resources > Config Maps*.
+. Select the project that contains the pods from *{sp1-title}*.
+. Select *Workloads > Config Maps*.
 . Click the *Create Config Map*  button.
-.. Enter `order-entry-keycloak-config` in the *Name* field.
-.. Enter `KEYCLOAK_CONFIG` in the *Key* field.
-.. Click the *Browse* button and select the _keycloak.json_ file that was downloaded in the previous section.
-. Click the *Create* button.
+. You will see an editor with the yaml representation for your Config Map.
+.. Enter `order-entry-keycloak-config` in the *metadata.name* field.
+.. Remove all the lines below *data*.
+.. Add a line `KEYCLOAK_CONFIG: |` under *data*. Make sure it is indented with one tab.
++
+NOTE: the pipe symbol (`|`) allows for multiline input, see link:https://yaml.org/spec/1.2/spec.html#id2795688[the yaml spec] for more details.
+
+.. Paste the contents of the _keycloak.json_ file in the next line. Make sure all lines are indented with two tabs.
+. Click the *Save* button.
 
 === Applying the SSO Config Map
 

--- a/walkthroughs/2-protecting-apps-sso/walkthrough.adoc
+++ b/walkthroughs/2-protecting-apps-sso/walkthrough.adoc
@@ -5,7 +5,7 @@
 :openshift-console-url: {openshift-host}/dashboards
 :sso-adapter-docs-url: https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/{sso-version}/html/securing_applications_and_services_guide/index
 :sso-realm-url: {user-sso-url}/auth/admin/master/console
-:sso-user-realm-url: {user-sso-url}/auth/admin/realm-{user-username}/console
+:sso-user-realm-url: {user-sso-url}/auth/admin/master/console/#/realms/realm-{user-username}
 //attributes
 :title: 2 - Protecting applications using single sign-on
 :sp1-title: Connecting applications using asynchronous messaging

--- a/walkthroughs/2-protecting-apps-sso/walkthrough.adoc
+++ b/walkthroughs/2-protecting-apps-sso/walkthrough.adoc
@@ -137,7 +137,7 @@ Do you see the *customer* username listed in the table?
 {standard-fail-text}
 
 [time=15]
-== Enabling SSO in the {create-messages-app}
+== Enabling SSO in the Order Entry System
 
 === Obtaining the SSO configuration
 

--- a/walkthroughs/2-protecting-apps-sso/walkthrough.adoc
+++ b/walkthroughs/2-protecting-apps-sso/walkthrough.adoc
@@ -74,12 +74,12 @@ Customer Application SSO, included with Red Hat Managed Integration, enables you
 Red Hat manages this instance, however there are some additional users with admin level privileges who can configure this instance.
 ****
 
-IMPORTANT: The realm used in this Solution Pattern is shared with *all* users on the cluster. *Do not use this realm for production applications*.
-
 Follow these steps to create a client.
 
-. Go to the link:{sso-realm-url}[{realm-display-name}, window="_blank"] realm, which is running on your {customer-sso-name} service.
-.. If prompted, enter the username `{shared-realm-username}` and password `{realm-password}`. You will see the *{realm-name}* realm if the login is successful.
+. Go to the link:{sso-realm-url}[Master, window="_blank"] realm, which is running on your {customer-sso-name} service.
+.. If prompted, login with your credentials. You will see the *Master* realm if the login is successful.
+.. Hover the *Master* realm dropdown and click on *Add Realm*.
+.. Enter Realm-*{user-username}* as the name and click *Create*. You will be redirected to your new realm.
 . Select *Clients* from the vertical navigation menu on the left side of the screen.
 . Click the *Create* button on the top right of the Clients screen.
 . On the *Add Client* screen:

--- a/walkthroughs/2-protecting-apps-sso/walkthrough.adoc
+++ b/walkthroughs/2-protecting-apps-sso/walkthrough.adoc
@@ -5,7 +5,7 @@
 :openshift-console-url: {openshift-host}/dashboards
 :sso-adapter-docs-url: https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/{sso-version}/html/securing_applications_and_services_guide/index
 :sso-realm-url: {user-sso-url}/auth/admin/master/console
-
+:sso-user-realm-url: {user-sso-url}/auth/admin/realm-{user-username}/console
 //attributes
 :title: 2 - Protecting applications using single sign-on
 :sp1-title: Connecting applications using asynchronous messaging
@@ -15,8 +15,8 @@
 :rhmi-sso-name: Managed Integration SSO instance
 :customer-sso-name: Customer Application SSO
 :client-name: {user-username}-order-entry-system
-:realm-name: solution-patterns
-:realm-display-name: Solution Patterns
+:realm-name: realm-{user-username}
+:realm-display-name: realm-{user-username}
 :shared-realm-username: developer
 :realm-password: password
 :standard-fail-text: Verify that you followed all the steps. If you continue to have issues, contact your administrator.
@@ -79,7 +79,7 @@ Follow these steps to create a client.
 . Go to the link:{sso-realm-url}[Master, window="_blank"] realm, which is running on your {customer-sso-name} service.
 .. If prompted, login with your credentials. You will see the *Master* realm if the login is successful.
 .. Hover the *Master* realm dropdown and click on *Add Realm*.
-.. Enter Realm-*{user-username}* as the name and click *Create*. You will be redirected to your new realm.
+.. Enter *realm-{user-username}* as the name and click *Create*. You will be redirected to your new realm.
 . Select *Clients* from the vertical navigation menu on the left side of the screen.
 . Click the *Create* button on the top right of the Clients screen.
 . On the *Add Client* screen:
@@ -108,8 +108,8 @@ To secure your application with single sign-on and allow additional users to log
 
 Follow these steps to create a new user and set that user's password.
 
-. Go to the link:{sso-realm-url}[{realm-display-name}, window="_blank"] realm, which is running on your {customer-sso-name} service.
-.. If prompted, enter the username `{shared-realm-username}` and password `{realm-password}`.
+. Go to the link:{sso-user-realm-url}[{realm-name}, window="_blank"] realm, which is running on your {customer-sso-name} service.
+.. If prompted, login with your credentials.
 . You will see the *{realm-name}* realm if the login is successful.
 . Select *Users* from the vertical navigation menu on the left side of the screen.
 . Click the *Add user* button on the top right of the Users screen.

--- a/walkthroughs/2-protecting-apps-sso/walkthrough.adoc
+++ b/walkthroughs/2-protecting-apps-sso/walkthrough.adoc
@@ -185,22 +185,19 @@ NOTE: the pipe symbol (`|`) allows for multiline input, see link:https://yaml.or
 === Applying the SSO Config Map
 
 . Log in to the link:{openshift-console-url}[OpenShift Console, window="_blank"].
-. Navigate to the *integration-solution-1-integrate-event-and-api-driven-apps* project.
-. Select *Applications > Deployments*.
-. Select the *rhmi-lab-nodejs-order-frontend* item from the *Deployments* list.
+. Select the project that contains the pods from *{sp1-title}*.
+. Select *Workloads > Deployment Configs*.
+. Select the *rhmi-lab-nodejs-order-frontend* item from the *Deployment Configs* list.
 . Select the *Environment* tab.
-.. Click *Add Value from Config Map or Secret*
-.. Enter `KEYCLOAK_CONFIG` in the *Name* column.
-.. Choose `order-entry-keycloak-config` from the *Select a resource* dropdown.
-.. Choose *KEYCLOAK_CONFIG* from the *Select key* menu.
-. Scroll down and click *Save*.
-. Select *Overview* on the left and find the *rhmi-lab-nodejs-order-frontend* in the list.
-. If a deployment is still in progress, wait for it to finish.
-. Open the URL listed beside the *rhmi-lab-nodejs-order-frontend* in either a private browser session, or a different browser to view the *{create-messages-app}* UI.
+.. Under *All values from existing config maps or secrets (envFrom)* click on the *Config Map/Secret* dropdown.
+.. Select *order-entry-keycloak-config* from the list and click *Save*.
+. Select *Deployment Configs* on the left and wait for the *rhmi-lab-nodejs-order-frontend* deployment to finish.
+. Select *Network > Routes* on the left and find the *order-entry-ui* route.
+. Open the URL listed beside the *order-entry-ui* route in either a private browser session, or a different browser to view the *{create-messages-app}* UI.
 +
 NOTE: Use a private session or different browser to avoid conflict with your old sessions.
 
-. A login screen with the title *walkthroughs Realm* is displayed.
+. A login screen with the title *{realm-name}* is displayed.
 . Enter `customer` in the *Username or email*.
 . Enter `customer-password` in the *Password* field.
 . Click the *Log In* button.

--- a/walkthroughs/2-protecting-apps-sso/walkthrough.adoc
+++ b/walkthroughs/2-protecting-apps-sso/walkthrough.adoc
@@ -4,7 +4,7 @@
 // URLs
 :openshift-console-url: {openshift-host}/dashboards
 :sso-adapter-docs-url: https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/{sso-version}/html/securing_applications_and_services_guide/index
-:sso-realm-url: {user-sso-url}
+:sso-realm-url: {user-sso-url}/auth/admin/master/console
 
 //attributes
 :title: 2 - Protecting applications using single sign-on

--- a/walkthroughs/3-low-code-api-development/walkthrough.adoc
+++ b/walkthroughs/3-low-code-api-development/walkthrough.adoc
@@ -46,14 +46,14 @@ It also allows you to identify important design decisions prior to coding and de
 * link:https://blog.openshift.com/[OpenShift Blog, window="_blank"]
 ****
 
-[type=walkthroughResource,serviceName=fuse]
+[type=walkthroughResource,serviceName=fuse-managed]
 .Red Hat Fuse Online
 ****
 * link:{fuse-url}[Console, window="_blank", id="resources-fuse-url"]
 * link:{fuse-documentation-url}[Fuse Documentation, window="_blank"]
 ****
 
-[type=walkthroughResource,serviceName=apicurio]
+[type=walkthroughResource,serviceName=apicurito]
 .Red Hat API Designer
 ****
 * link:{apicurio-url}[Console, window="_blank"]

--- a/walkthroughs/4-protecting-apis/walkthrough.adoc
+++ b/walkthroughs/4-protecting-apis/walkthrough.adoc
@@ -27,7 +27,7 @@ Learn how to import an API into Red Hat 3scale API Management Platform and secur
 * link:https://blog.openshift.com/[OpenShift Blog, window="_blank"]
 ****
 
-[type=walkthroughResource,serviceName=fuse]
+[type=walkthroughResource,serviceName=fuse-managed]
 .Red Hat Fuse Online
 ****
 * link:{fuse-url}[Console, window="_blank", id="resources-fuse-url"]

--- a/walkthroughs/5-adding-data-sync-graphql/walkthrough.adoc
+++ b/walkthroughs/5-adding-data-sync-graphql/walkthrough.adoc
@@ -3,8 +3,10 @@
 
 // URLs
 :openshift-console-url: {openshift-host}/dashboards
-:sso-realm-url: {user-sso-url}/auth/admin/solution-patterns/console/index.html
+:sso-realm-url: {user-sso-url}/auth/admin/master/console
+:sso-user-realm-url: {user-sso-url}/auth/admin/master/console/#/realms/sync-realm-{user-username}
 :data-sync-documentation-url: https://access.redhat.com/documentation/en-us/red_hat_managed_integration/{rhmi-version}/html-single/developing_a_data_sync_app/index
+:openshift-config-maps-url: {openshift-host}/k8s/ns/{walkthrough-namespace}/configmaps
 
 //attributes
 :title: 5 - Adding Data Sync to your application with GraphQL
@@ -12,8 +14,8 @@
 :data-sync-name: Data Sync
 :data-sync-showcase-app: AeroGear Showcase application
 :customer-sso-name: Customer Application SSO
-:realm-name: solution-patterns
-:realm-display-name: Solution Patterns
+:realm-name: sync-realm-{user-username}
+:realm-display-name: sync-realm-{user-username}
 :shared-realm-username: developer
 :realm-password: password
 :standard-fail-text: Verify that you followed all the steps. If you continue to have issues, contact your administrator.
@@ -169,8 +171,10 @@ IMPORTANT: The realm used in this Solution Pattern is shared with *all* users on
 
 Follow these steps to create a client for the front-end app.
 
-. Go to the link:{sso-realm-url}[{realm-display-name}, window="_blank"] realm, which is running on your {customer-sso-name} service.
-.. If prompted, enter the username `{shared-realm-username}` and password `{realm-password}`. You will see the *{realm-name}* realm if the login is successful.
+. Go to the link:{sso-realm-url}[Master, window="_blank"] realm, which is running on your {customer-sso-name} service.
+.. If prompted, log in with your username and password. You will see the *Master* realm if the login is successful.
+.. Hover the realm dropdown in the top right and click on *Add Realm*.
+.. Enter *{realm-name}* as the name and click *Create*. You will be redirected to your new realm.
 . Select *Clients* from the vertical navigation menu on the left side of the screen.
 . Click the *Create* button on the top right of the Clients screen.
 . On the *Add Client* screen:
@@ -181,7 +185,7 @@ Follow these steps to create a client for the front-end app.
 {user-username}-frontend
 ----
 .. Verify the *Client Protocol* is set to *openid-connect*.
-.. Click *Save*. You will see the *Settings* screen for the *{client-name}* client if the save is successful.
+.. Click *Save*. You will see the *Settings* screen for the *{user-username}-frontend* client if the save is successful.
 . On the *Settings* screen:
 .. Change *Valid Redirect URIs* to:
 +
@@ -194,8 +198,8 @@ Follow these steps to create a client for the front-end app.
 .. Click on the *Installation* tab, and select `Keycloak OIDC JSON` format. Copy the content displayed or use the `Download` button to save the configuration file.
 
 . Update the configuration of the frontend app to secure it:
-.. Go to the link:{openshift-host}/console/project/{walkthrough-namespace}/browse/config-maps[OpenShift Config Maps] page.
-.. Select the config map that is called `webapp-config`, and edit it by selecting `Edit` under the `Actions` button.
+.. Go to the link:{openshift-config-maps-url}[OpenShift Config Maps, window="_blank"] page.
+.. Select the config map that is called `webapp-config`, and edit it by selecting `Yaml` tab.
 .. Add a new `auth` section to the config map by pasting the content that was copied in the previous step.
 .. Rename the `auth-server-url` attribute to `url` and the `resource` attribute to `clientId`.
 .. Save it
@@ -211,9 +215,9 @@ Does the content of the config map look as follows:
        "wsServerUrl": ((window.location.protocol === "https:") ? "wss://" : "ws://") + window.location.hostname + "/graphql"
      },
      "auth": {
-       "realm": "walkthroughs",
-    	 "url": " {user-sso-url}/auth",
-   	   "ssl-required": "none",
+       "realm": "{realm-name}",
+       "url": "{user-sso-url}/auth",
+   	   "ssl-required": "external",
    	   "clientId": "{user-username}-frontend",
    	   "public-client": true,
    	   "confidential-port": 0
@@ -232,8 +236,8 @@ Verify that you followed each step in the procedure above.  If you are still hav
 
 Follow these steps to create a client.
 
-. Go to the link:{sso-realm-url}[{realm-display-name}, window="_blank"] realm, which is running on your {customer-sso-name} service.
-.. If prompted, enter the username `{shared-realm-username}` and password `{realm-password}`.
+. Go to the link:{sso-user-realm-url}[{realm-display-name}, window="_blank"] realm, which is running on your {customer-sso-name} service.
+.. If prompted, log in with your username and password.
 . You will see the *{realm-name}* realm if the login is successful.
 . Select *Clients* from the vertical navigation menu on the left side of the screen.
 . Click the *Create* button on the top right of the Clients screen.
@@ -259,33 +263,36 @@ Follow these steps to create a client.
 .. Click *Reset Password*
 
 . Update the backend to use the downloaded configuration file:
-.. Go to the link:{openshift-host}/console/project/{walkthrough-namespace}/browse/config-maps[OpenShift Config Maps] page.
-.. Click *Create Config Map*.
-.. When prompted for *Name*, enter:
+.. Go to the link:{openshift-config-maps-url}[OpenShift Config Maps, window="_blank"] page.
+.. Click *Create Config Map*. You will see an editor with the yaml representation for your Config Map.
+.. Enter `showcase-server-idm-config` in the *metadata.name* field.
+.. Remove all the lines below *data*.
+.. Add a line `keycloak.json: |` under *data*. Make sure it is indented with one tab.
 +
-----
-showcase-server-idm-config
-----
-.. When prompted for *Key*, enter:
-+
-----
-keycloak.json
-----
-.. For *Value*, click *Browse* and load the json file that you downloaded previously.
+NOTE: the pipe symbol (`|`) allows for multiline input, see link:https://yaml.org/spec/1.2/spec.html#id2795688[the yaml spec] for more details.
+
+.. Paste the contents of the _keycloak.json_ file in the next line. Make sure all lines are indented with two tabs.
 .. Click *Create*. The config map object is created.
-.. Choose *Deployments* from the *Applications* menu.
-.. Select the deployment config for `ionic-showcase-server`.
-.. Click on the *Configuration* tab, and scroll to the *Volumes* section.
-.. Click on the *Add Config Files* option at the bottom of the section.
-.. Choose the `showcase-server-idm-config` config map as the *Source*.
-.. Set the value for *Mount Path* to:
+.. Select *Deployment Configs* on the left click on *ionic-showcase-server*.
+.. Select the *Yaml* tab to edit the deployment config.
+.. Find the *volumes* section under `spec.template.spec`.
+.. Add the following entry to the *volumes* section:
 +
 ----
-/tmp/keycloak
+- name: backend-config
+  configMap:
+    name: showcase-server-idm-config
+    defaultMode: 420
 ----
 
-.. Click *Add* to trigger a new deployment.
-.. Click the *Environment* tab and click *Add Value*.
+.. Find the *volumeMounts* section under `spec.template.spec.containers`
+.. Add the following entry to the *volumeMounts* section:
++
+----
+- { name: backend-config, mountPath: /tmp/keycloak }
+----
+
+.. Click the *Environment* tab and click *Add Value* in the *Single values (env)* section.
 .. Set Name to:
 +
 ----
@@ -320,7 +327,7 @@ For example, use the browser on your mobile device as well as using the browser 
 
 To get the url of your app:
 
-. Go to link:{route-ionic-showcase-server-host}[Data Sync].
+. Go to link:{route-ionic-showcase-server-host}[Data Sync, window="_blank"].
 
 image::images/showcase.png[showcase, role="integr8ly-img-responsive"]
 
@@ -354,11 +361,11 @@ Verify that you followed each step in the procedure above.  If you are still hav
 
 . On your mobile device:
 .. Log into the {data-sync-showcase-app}.
+.. Click on the `Create Task` button.
+.. Enter a title and description but do not yet create the task.
 .. Activate airplane mode or disable network connectivity.
-.. Create a new task.
+.. Now click on the `Create` button.
 The task should be created and the *Offline Changes* button in the footer should contain one change.
-.. Make a few more changes by either editing existing tasks, or creating new ones.
-.. Review all the changes by clicking the *Offline Changes* button.
 
 . On your laptop:
 .. Log into the {data-sync-showcase-app}.
@@ -389,18 +396,18 @@ Verify that you followed each step in the procedure above.  If you are still hav
 . On your mobile device:
 .. Log into the {data-sync-showcase-app}.
 .. Create a task `todo A`.
-.. Activate airplane mode or disable network connectivity.
+.. Click on the `Edit` button next to the task, then activate airplane mode or disable network connectivity.
 .. Edit the task description to add the text `edited on mobile`.
 
 . On your laptop:
-.. Log into the {data-sync-showcase-app}.
+.. Log into the {data-sync-showcase-app} and click on the `Edit` button next to `todo A`.
 .. Simulate offline mode. For example, in Chrome, press F12 to open *Developer Tools* and select *offline* in  the *Network* tab.
 .. Edit the `todo A` task, change the text to `todo B`.
 
 . Bring both of your devices back online, the tasks should sync without a conflict.
 
 . On your mobile device:
-.. Activate airplane mode or disable network connectivity.
+.. Click the `Edit` button next to `todo B` and activate airplane mode or disable network connectivity.
 .. Edit task `todo B` change the description to:
 +
 ----
@@ -408,7 +415,7 @@ Conflicting description from mobile
 ----
 
 . On your laptop:
-.. Simulate offline mode. For example, in Chrome, press F12 to open *Developer Tools* and select *offline* in  the *Network* tab.
+.. Click on the `Edit` button next to `task B`, then simulate offline mode. For example, in Chrome, press F12 to open *Developer Tools* and select *offline* in  the *Network* tab.
 .. Edit task `todo B` change the description to:
 +
 ----


### PR DESCRIPTION
Make WT2 compatible with OS4:

* instead of sharing one realm with other users, the user is instructed to create their own realm
* rewrite OS3 specific parts for OS4
* fix some status indicators (wrong service names)

Make WT5 compatible with OS4:

* instead of sharing one realm with other users, the user is instructed to create their own realm
* rewrite OS3 specific parts for OS4