### PR TITLE
INTLY-5928 Updated prettyName

### DIFF
--- a/walkthroughs-config.json
+++ b/walkthroughs-config.json
@@ -1,3 +1,3 @@
 {
-    "prettyName": "Red Hat Solution Patterns (OS4)"
+    "prettyName": "Red Hat Solution Patterns"
 }


### PR DESCRIPTION
Removed "(OS4)" from the prettyName for the Solution Pattern heading as these now only show up on OS4 clusters. 