### PR TITLE
INTLY-8149 - use attribute for fuse namespace

### DIFF
--- a/hidden_walkthroughs/4-protecting-apis/walkthrough.adoc
+++ b/hidden_walkthroughs/4-protecting-apis/walkthrough.adoc
@@ -73,7 +73,7 @@ NOTE: Ask an administrator to grant you the necessary 3scale permission if *New 
 . Select the *Import from OpenShift* option. If this option is not enabled, click the *Authenticate to enable this option* link and choose *Allow selected permissions*.
 . If you used the *Authenticate to enable this option* link, verify that you have reselected *Import from OpenShift* after being redirected.
 . In the SERVICE section:
-.. Verify the *Namespace* field has *redhat-rhmi-fuse* selected.
+.. Verify the *Namespace* field has *{fuse-namespace}* selected.
 .. Verify the *Name* field has *i-greeting-integration-{user-username}* selected.
 . Click *Create Product*.
 +

--- a/walkthroughs/3-low-code-api-development/walkthrough.adoc
+++ b/walkthroughs/3-low-code-api-development/walkthrough.adoc
@@ -370,10 +370,10 @@ By default, Fuse Online does not expose an *Integration* to the public internet 
 === Find the Greeting Service Internal Hostname
 
 . Login to the link:{openshift-console-url}[OpenShift Console, window="_blank"].
-. Go to *Home > Projects* and select the project named with the following format: `redhat-rhmi-fuse`.
+. Go to *Home > Projects* and select the project named with the following format: `{fuse-namespace}`.
 . Choose *Networking > Services* from the left menu.
 . Make sure there is a *i-greeting-integration-{user-username}* item in the *Services* list.
-. Take a note of the hostname: `i-greeting-integration-{user-username}.redhat-rhmi-fuse.svc.cluster.local`.
+. Take a note of the hostname: `i-greeting-integration-{user-username}.{fuse-namespace}.svc.cluster.local`.
 
 === Creating a cURL Deployment
 
@@ -398,7 +398,7 @@ oc run curl --image=curlimages/curl --restart=Never \
 --command -- curl -X POST \
 --data '{"name":"OpenShift"}' \
 -H 'content-type: application/json' \
-http://i-greeting-integration-{user-username}.redhat-rhmi-fuse.svc.cluster.local:8080/greeting -vvv
+http://i-greeting-integration-{user-username}.{fuse-namespace}.svc.cluster.local:8080/greeting -vvv
 ----
 
 . Verify the cURL container ran successfully by checking the logs for a *200 OK* response with this command:


### PR DESCRIPTION
Update walkthroughs to use the `fuse-namespace` attribute

Jira:
* https://issues.redhat.com/browse/INTLY-8149

Tutorial Web App PR:
* https://github.com/integr8ly/tutorial-web-app/pull/589