### PR TITLE
remove note only relevant to workshop installations

### DIFF
--- a/walkthroughs/1-connecting-apps-asynchronous-messaging/walkthrough.adoc
+++ b/walkthroughs/1-connecting-apps-asynchronous-messaging/walkthrough.adoc
@@ -175,10 +175,6 @@ To create a connector for the Fuse RESTful API, register the OpenAPI definition 
 Follow these steps to create an API Connector.
 
 . Log in to the link:{fuse-url}[Red Hat Fuse Online, window="_blank", id="creating-connections-1"] console.
-+
-NOTE: You are not logging into the shared Fuse Online instance, available from the link:/[All services tab].
-Starting this Solution Pattern provisioned an instance of Fuse Online which is not shared with other cluster users.
-
 . Select *Customizations > API Client Connectors* from vertical navigation menu on the left.
 . Select the *Create API Connector* button to start the *API Client Connector* wizard.
 . When prompted to *Upload OpenAPI Document*, select *Use a URL*:


### PR DESCRIPTION
remove the note about per-user fuse instance as it's misleading on workshop installations.